### PR TITLE
removed force includeModules for Meteor projects

### DIFF
--- a/lib/controllers/project.js
+++ b/lib/controllers/project.js
@@ -233,7 +233,6 @@ Project.prototype.deploy = function(projectId, dir, includeModules, registry, me
             cb(null, dir);
             break;
           case Project.types.METEOR:
-            includeModules = true;
             modulus.io.print('Meteor project detected...');
 
             projectController.demeteorize(dir, meteorDebug, function(err, out) {


### PR DESCRIPTION
As per https://github.com/onmodulus/modulus-cli/issues/66 I have removed the includeModules flag enforcement for Meteor projects. Currently it takes > 15mins to compress projects with npm dependencies and this should be done on the server we are deploying to. This problem will only get worse as the Meteor and npm ecosystem get closer.

This can still be optionally set using the --include-modules commend.
